### PR TITLE
build: drop node v16 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "typescript": "^5.6.3"
       },
       "engines": {
-        "node": "^16 || ^18 || ^20 || ^22"
+        "node": "^18 || ^20 || ^22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^16 || ^18 || ^20 || ^22"
+    "node": "^18 || ^20 || ^22"
   },
   "scripts": {
     "lint": "eslint '{src,tests}/**/*.ts' --fix",


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Drops support for Node v16

Others who have dropped support:
- [heroku](https://devcenter.heroku.com/articles/nodejs-support#supported-runtimes)
- [github actions](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- [node](https://endoflife.date/nodejs)

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
