### PR TITLE
feat: use native fetch as the default request library 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-        "jose": "^5.9.6",
-        "node-fetch": "^2.7.0"
+        "jose": "^5.9.6"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.2.0",
@@ -7646,25 +7645,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8986,11 +8966,6 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -9505,20 +9480,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "beachball-check": "beachball check"
   },
   "dependencies": {
-    "jose": "^5.9.6",
-    "node-fetch": "^2.7.0"
+    "jose": "^5.9.6"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",

--- a/src/classes/PassageBase/PassageBase.ts
+++ b/src/classes/PassageBase/PassageBase.ts
@@ -14,7 +14,7 @@ export class PassageBase {
 
     /**
      * Handle errors from PassageFlex API
-     * @param {unknown} err error from node-fetch request
+     * @param {unknown} err error from fetch request
      * @return {Promise<void>}
      */
     protected async parseError(err: unknown): Promise<Error> {

--- a/src/classes/PassageError/PassageError.ts
+++ b/src/classes/PassageError/PassageError.ts
@@ -21,7 +21,7 @@ export class PassageError extends Error {
     }
     /**
      * Initialize a new PassageError instance.
-     * @param {ResponseError} err error from node-fetch request
+     * @param {ResponseError} err error from fetch request
      * @return {Promise<PassageError>}
      */
     public static async fromResponseError(err: ResponseError): Promise<PassageError> {

--- a/src/utils/apiConfiguration.ts
+++ b/src/utils/apiConfiguration.ts
@@ -1,5 +1,4 @@
 import { Configuration, ConfigurationParameters } from '../generated';
-import fetch from 'node-fetch';
 
 /**
  * Initialize defaults for Configuration
@@ -10,7 +9,7 @@ import fetch from 'node-fetch';
 export function apiConfiguration(config?: ConfigurationParameters): Configuration {
     const configuration = new Configuration({
         accessToken: config?.accessToken,
-        fetchApi: fetch as unknown as ConfigurationParameters['fetchApi'],
+        fetchApi: config?.fetchApi,
         headers: {
             ...config?.headers,
             'Authorization': `Bearer ${config?.accessToken}`,


### PR DESCRIPTION


<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Drops `node-fetch` in favor of Node's native `fetch` library as the default request library
  - fetch was [experimentally](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental) available in Node v18 and went [stable](https://nodejs.org/en/blog/announcements/v21-release-announce#stable-fetchwebstreams) in Node v21
## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
