### PR TITLE
feat!: update auth.createRegisterTransaction and user.revokeDevice signatures to use two separate arguments

### DIFF
--- a/src/classes/Auth/Auth.spec.ts
+++ b/src/classes/Auth/Auth.spec.ts
@@ -15,10 +15,7 @@ describe('Auth e2e', () => {
 
     describe('createRegisterTransaction', () => {
         it('should return the transaction ID', async () => {
-            const transactionId = await passage.auth.createRegisterTransaction({
-                externalId: 'test',
-                passkeyDisplayName: 'test',
-            });
+            const transactionId = await passage.auth.createRegisterTransaction('test', 'test');
             expect(transactionId).toEqual(expect.any(String));
         });
     });

--- a/src/classes/Auth/Auth.ts
+++ b/src/classes/Auth/Auth.ts
@@ -1,6 +1,5 @@
 import { AuthenticateApi, TransactionsApi } from '../../generated';
 import { PassageBase, PassageInstanceConfig } from '../PassageBase';
-import { RegisterTransactionArgs } from './types';
 
 /**
  * Auth class that provides methods for creating and validating passkey transactions.
@@ -22,14 +21,18 @@ export class Auth extends PassageBase {
     /**
      * Create a transaction to start a user's registration process
      *
-     * @param {RegisterTransactionArgs} args The required values to create a transaction
+     * @param {string} externalId The external ID of the user to register
+     * @param {string} passkeyDisplayName The display name of the passkey to use
      * @return {Promise<string>} The transaction ID
      */
-    public async createRegisterTransaction(args: RegisterTransactionArgs): Promise<string> {
+    public async createRegisterTransaction(externalId: string, passkeyDisplayName: string): Promise<string> {
         try {
             const response = await this.transactionClient.createRegisterTransaction({
                 appId: this.config.appId,
-                registerTransactionArgs: args,
+                registerTransactionArgs: {
+                    externalId,
+                    passkeyDisplayName,
+                },
             });
 
             return response.transactionId;

--- a/src/classes/Auth/index.ts
+++ b/src/classes/Auth/index.ts
@@ -1,2 +1,1 @@
 export * from './Auth';
-export * from './types';

--- a/src/classes/Auth/types.ts
+++ b/src/classes/Auth/types.ts
@@ -1,3 +1,0 @@
-import { RegisterTransactionArgs } from '../../generated';
-
-export { RegisterTransactionArgs };

--- a/src/classes/User/User.ts
+++ b/src/classes/User/User.ts
@@ -1,6 +1,6 @@
 import { ResponseError, UserDevicesApi, UserInfo, UsersApi, WebAuthnDevices } from '../../generated';
 import { PassageBase, PassageInstanceConfig } from '../PassageBase';
-import { PassageUser, RevokeDeviceArgs } from './types';
+import { PassageUser } from './types';
 
 /**
  * User class for handling operations to get and update user information.
@@ -77,16 +77,17 @@ export class User extends PassageBase {
     /**
      * Revoke a user's device by their external ID and the device ID
      *
-     * @param {RevokeDeviceArgs} args The external ID used to associate the user with Passage and the device ID
+     * @param {string} externalId The external ID of the user whose device to revoke
+     * @param {string} deviceId The device ID to revoke
      * @return {Promise<void>}
      */
-    public async revokeDevice(args: RevokeDeviceArgs): Promise<void> {
+    public async revokeDevice(externalId: string, deviceId: string): Promise<void> {
         try {
-            const user = await this.get(args.externalId);
+            const user = await this.get(externalId);
             await this.deviceClient.deleteUserDevices({
                 appId: this.config.appId,
-                deviceId: args.deviceId,
                 userId: user.id,
+                deviceId,
             });
         } catch (err) {
             throw await this.parseError(err);

--- a/src/classes/User/types.ts
+++ b/src/classes/User/types.ts
@@ -14,9 +14,4 @@ export interface PassageUser {
     webauthnTypes: WebAuthnType[];
 }
 
-export interface RevokeDeviceArgs {
-    externalId: string;
-    deviceId: string;
-}
-
 export { UserStatus, WebAuthnDevices, WebAuthnType, WebAuthnIcons };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- updates the func signatures of `PassageFlex.auth.createRegisterTransaction` and `Passage.user.revokeDevice` to use two separate arguments instead of a single object argument for consistency

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
